### PR TITLE
Export gate polish and production-ready palette (D3)

### DIFF
--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -186,10 +186,10 @@ async fn export_zip(State(st): State<AppState>, Path(id): Path<String>) -> Resul
         return Err((StatusCode::CONFLICT, "Export blocked: Human interrupt active".into()));
     }
     if cfg_ui.require_dual_signoff {
-        let a = rstate.signoff.get("Analyst").copied().unwrap_or(false);
+        let a = rstate.signoff.get("Media Team").copied().unwrap_or(false);
         let s = rstate.signoff.get("Strategy Head").copied().unwrap_or(false);
         if !(a && s) {
-            return Err((StatusCode::FORBIDDEN, "Export blocked: Dual signoff required".into()));
+            return Err((StatusCode::FORBIDDEN, "Export blocked: Dual signoff required (Media Team and Strategy Head)".into()));
         }
     }
     use std::io::Read;

--- a/demo_shortcuts_ledger.md
+++ b/demo_shortcuts_ledger.md
@@ -48,15 +48,35 @@ This document tracks shortcuts taken in the demo/kiosk track that need to be add
 - **Where**: `frontend/src/routes/Issue.tsx` hypothesis panel
 - **Recall**: Add real-time confidence updates based on new signals
 
+### 9. Export Formats Mock (D3)
+- **What**: Export format options (PDF, CSV, JSON) are UI-only
+- **Where**: `frontend/src/routes/Issue.tsx` lines 434-441, `frontend/src/routes/Export.tsx`
+- **Recall**: Implement actual format conversion in backend
+- **Impact**: Low - ZIP export works, other formats need implementation
+
+### 10. Export Gate Hardcoded Roles (D3)
+- **What**: Export validation checks for hardcoded "Media Team" role
+- **Where**: `backend/api/src/main.rs` lines 189-193
+- **Recall**: Load roles dynamically from roles.v1.json contract
+- **Note**: Fixed from "Analyst" to "Media Team" but still hardcoded
+
+### 11. CSS Variables for Production Polish (D3)
+- **What**: Added CSS custom properties for consistent theming
+- **Where**: `frontend/src/index.css` lines 2-15
+- **Recall**: Consider dark/light theme switching in production
+- **Impact**: Low - improves maintainability
+
 ## Recall Priority
 
 1. **High**: Hypotheses generation (blocking for real anomaly detection)
 2. **High**: Hypothesis state management (needed for learning loop)
-3. **Medium**: Dynamic role loading from contracts
-4. **Medium**: Lens-specific content generation
-5. **Low**: Evidence link integration
-6. **Low**: Data Scientist backend features
-7. **Low**: Data Scientist backend features
+3. **High**: Export format implementations (PDF, CSV, JSON)
+4. **Medium**: Dynamic role loading from contracts
+5. **Medium**: Lens-specific content generation
+6. **Medium**: Dynamic hypothesis counts in radar
+7. **Low**: Evidence link integration
+8. **Low**: Data Scientist backend features
+9. **Low**: Theme switching system
 
 ## Notes
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,49 @@
 @tailwind base; @tailwind components; @tailwind utilities;
-:root { --ring: #7DD3FC; }
-body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
-.card { background: #0f2236; border-radius: 16px; border: 1px solid rgba(255,255,255,0.06); box-shadow: 0 10px 30px rgba(0,0,0,0.35); }
-.btn { padding: 10px 16px; border-radius: 12px; border: 1px solid rgba(255,255,255,0.12); background: #162b44; }
-.btn:hover { background: #1b334f; }
+:root { 
+  --ring: #06b6d4;
+  --primary: #06b6d4;
+  --primary-dark: #0891b2;
+  --secondary: #a855f7;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --card-bg: #0f2236;
+  --card-bg-alt: #11253c;
+  --card-border: rgba(6, 182, 212, 0.15);
+  --text-primary: #f3f4f6;
+  --text-secondary: #d1d5db;
+  --text-muted: #9ca3af;
+}
+body { 
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; 
+  color: var(--text-primary);
+  background-color: #030712;
+}
+.card { 
+  background: var(--card-bg); 
+  border-radius: 16px; 
+  border: 1px solid var(--card-border); 
+  box-shadow: 0 10px 30px rgba(0,0,0,0.35); 
+}
+.btn { 
+  padding: 10px 16px; 
+  border-radius: 12px; 
+  border: 1px solid rgba(255,255,255,0.12); 
+  background: #162b44;
+  transition: all 0.2s ease;
+  font-weight: 500;
+}
+.btn:hover { 
+  background: #1b334f;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+.btn:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
 .kb { position: fixed; bottom: 16px; right: 16px; opacity: 0.7; font-size: 12px; }
+/* Animations */
 @keyframes fade-in {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
@@ -15,3 +54,58 @@ body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, I
   50% { opacity: 0.5; }
 }
 .animate-pulse { animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
+
+/* Production-ready utility classes */
+.glass-morphism {
+  background: rgba(15, 34, 54, 0.8);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(6, 182, 212, 0.2);
+}
+
+.text-gradient {
+  background: linear-gradient(to right, var(--primary), var(--secondary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.shadow-glow {
+  box-shadow: 0 0 20px rgba(6, 182, 212, 0.3);
+}
+
+.btn-primary {
+  background: linear-gradient(to right, var(--primary), var(--primary-dark));
+  border: 1px solid var(--primary);
+  color: white;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(to right, var(--primary-dark), #065f46);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(6, 182, 212, 0.4);
+}
+
+.btn-danger {
+  background: var(--danger);
+  border: 1px solid var(--danger);
+  color: white;
+}
+
+.btn-secondary {
+  background: var(--secondary);
+  border: 1px solid var(--secondary);
+  color: white;
+}
+
+/* Focus states for accessibility */
+.btn:focus-visible,
+.card:focus-within {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* Smooth transitions */
+* {
+  transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}

--- a/frontend/src/routes/Export.tsx
+++ b/frontend/src/routes/Export.tsx
@@ -1,16 +1,158 @@
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useState } from 'react'
 
 const API = import.meta.env.VITE_API_URL || 'http://localhost:8787'
+
 export default function Export(){
   const { id } = useParams()
-  async function download(){ const r = await fetch(`${API}/export/${id}`, { method:'POST' }); if(!r.ok){ alert(await r.text()); return } const blob = await r.blob(); const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = `iamc_export_${id}.zip`; a.click(); setTimeout(()=> URL.revokeObjectURL(url), 2000) }
+  const navigate = useNavigate()
+  const [isExporting, setIsExporting] = useState(false)
+  const [exportFormat, setExportFormat] = useState<'zip' | 'pdf' | 'csv' | 'json'>('zip')
+  
+  async function download(format: string = 'zip'){ 
+    setIsExporting(true)
+    try {
+      const endpoint = format === 'zip' ? `/export/${id}` : `/export/${id}?format=${format}`
+      const r = await fetch(`${API}${endpoint}`, { method:'POST' })
+      
+      if(!r.ok){ 
+        alert(await r.text())
+        return 
+      } 
+      
+      const blob = await r.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `iamc_export_${id}.${format}`
+      a.click()
+      setTimeout(()=> URL.revokeObjectURL(url), 2000)
+    } finally {
+      setIsExporting(false)
+    }
+  }
+  
   return (
-    <div className="grid place-items-center h-screen">
-      <div className="text-center space-y-3">
-        <div className="text-3xl font-extrabold">Export Package</div>
-        <div className="opacity-70 text-sm">Export requires dual sign-off if enabled. Use the review bar above to sign as Media Team and Strategy Head.</div>
-        <div className="opacity-80">Download the full brief + assets bundle.</div>
-        <button className="btn" onClick={download}>Download ZIP</button>
+    <div className="min-h-screen bg-[radial-gradient(1000px_600px_at_50%_50%,#12345633,transparent)] grid place-items-center">
+      <div className="max-w-4xl w-full px-8">
+        <div className="card p-8 bg-gradient-to-br from-[#0f2236] to-[#0a1929] border-2 border-cyan-900/50">
+          <div className="text-center mb-8">
+            <h1 className="text-4xl font-extrabold mb-3 flex items-center justify-center gap-3">
+              <svg className="w-10 h-10 text-cyan-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V2" />
+              </svg>
+              Export Intelligence Package
+            </h1>
+            <p className="text-lg opacity-80">Secure distribution of intelligence briefings and assets</p>
+            <p className="text-sm opacity-60 mt-2">Export requires dual sign-off when enabled. Use the review bar to complete authorization.</p>
+          </div>
+          
+          <div className="grid grid-cols-2 gap-6 mb-8">
+            <div className="bg-[#11253c]/50 rounded-lg p-6">
+              <h3 className="font-semibold text-cyan-300 mb-3">Export Requirements</h3>
+              <ul className="space-y-2 text-sm">
+                <li className="flex items-center gap-2">
+                  <svg className="w-4 h-4 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                  <span>Media Team sign-off required</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <svg className="w-4 h-4 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                  <span>Strategy Head sign-off required</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <svg className="w-4 h-4 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                  </svg>
+                  <span>No active interrupts</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <svg className="w-4 h-4 text-cyan-400" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
+                  </svg>
+                  <span>Valid export window</span>
+                </li>
+              </ul>
+            </div>
+            
+            <div className="bg-[#11253c]/50 rounded-lg p-6">
+              <h3 className="font-semibold text-cyan-300 mb-3">Package Contents</h3>
+              <ul className="space-y-2 text-sm">
+                <li className="flex items-center gap-2">
+                  <span className="text-cyan-400">•</span>
+                  <span>Full intelligence brief with analysis</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-cyan-400">•</span>
+                  <span>Evidence sources & provenance</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-cyan-400">•</span>
+                  <span>Candidate hypotheses & confidence scores</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-cyan-400">•</span>
+                  <span>Generated communication assets</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-cyan-400">•</span>
+                  <span>Complete audit trail</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+          
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex items-center gap-4">
+              <label className="text-sm opacity-80">Export Format:</label>
+              <select
+                value={exportFormat}
+                onChange={(e) => setExportFormat(e.target.value as typeof exportFormat)}
+                className="bg-[#11253c] px-4 py-2 rounded-lg text-sm border border-cyan-900/30 focus:border-cyan-400/50 transition-colors"
+              >
+                <option value="zip">ZIP Package - Complete bundle</option>
+                <option value="pdf">PDF Report - Formatted document</option>
+                <option value="csv">CSV Data - Tabular export</option>
+                <option value="json">JSON Export - Structured data</option>
+              </select>
+            </div>
+            
+            <div className="flex gap-4">
+              <button 
+                className="btn bg-gradient-to-r from-cyan-600 to-cyan-700 hover:from-cyan-700 hover:to-cyan-800 px-8 py-3 text-lg font-semibold shadow-lg disabled:opacity-50 disabled:cursor-not-allowed" 
+                onClick={() => download(exportFormat)}
+                disabled={isExporting}
+              >
+                {isExporting ? (
+                  <span className="flex items-center gap-2">
+                    <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                    Preparing Export...
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-2">
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                    Download {exportFormat.toUpperCase()}
+                  </span>
+                )}
+              </button>
+              
+              <button 
+                className="btn opacity-80 hover:opacity-100" 
+                onClick={() => navigate(-1)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/routes/Issue.tsx
+++ b/frontend/src/routes/Issue.tsx
@@ -83,6 +83,8 @@ export default function Issue(){
   
   const [assets, setAssets] = useState<any>(null)
   const [showHypotheses, setShowHypotheses] = useState(true)
+  const [exportFormat, setExportFormat] = useState<'zip' | 'pdf' | 'csv' | 'json'>('zip')
+  const [isExporting, setIsExporting] = useState(false)
   
   if (isLoading) return <div className="grid place-items-center h-screen">Loading…</div>
   
@@ -136,6 +138,33 @@ export default function Issue(){
       console.log(`${action} hypothesis ${hypothesisId}`)
     } catch (err) {
       console.error('Failed to perform hypothesis action:', err)
+    }
+  }
+
+  const handleExport = async () => {
+    setIsExporting(true)
+    try {
+      const endpoint = exportFormat === 'zip' ? `/export/${id}` : `/export/${id}?format=${exportFormat}`
+      const response = await fetch(`${API}${endpoint}`, { method: 'POST' })
+      
+      if (!response.ok) {
+        const errorText = await response.text()
+        alert(errorText)
+        return
+      }
+      
+      const blob = await response.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `iamc_export_${id}.${exportFormat}`
+      a.click()
+      setTimeout(() => URL.revokeObjectURL(url), 2000)
+    } catch (err) {
+      console.error('Export failed:', err)
+      alert('Export failed. Please try again.')
+    } finally {
+      setIsExporting(false)
     }
   }
 
@@ -384,6 +413,89 @@ export default function Issue(){
           )}
           <div className="mt-4 text-xs opacity-50">
             Note: Local AI models and API integration planned for future release. Currently using template-based generation.
+          </div>
+        </div>
+
+        {/* Export Gate Section */}
+        <div className="card p-4 bg-gradient-to-br from-[#0f2236] to-[#0a1929] border-2 border-cyan-900/50">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h3 className="font-semibold text-lg flex items-center gap-2">
+                <svg className="w-5 h-5 text-cyan-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V2" />
+                </svg>
+                Export Intelligence Package
+              </h3>
+              <p className="text-sm opacity-60 mt-1">Export requires dual sign-off when enabled</p>
+            </div>
+            <div className="flex items-center gap-3">
+              {/* Format selector */}
+              <select
+                value={exportFormat}
+                onChange={(e) => setExportFormat(e.target.value as typeof exportFormat)}
+                className="bg-[#11253c] px-3 py-2 rounded-lg text-sm border border-cyan-900/30 focus:border-cyan-400/50 transition-colors"
+              >
+                <option value="zip">ZIP Package</option>
+                <option value="pdf">PDF Report</option>
+                <option value="csv">CSV Data</option>
+                <option value="json">JSON Export</option>
+              </select>
+              
+              <button
+                onClick={handleExport}
+                disabled={isExporting}
+                className="btn bg-gradient-to-r from-cyan-600 to-cyan-700 hover:from-cyan-700 hover:to-cyan-800 disabled:opacity-50 disabled:cursor-not-allowed px-6 py-2 font-semibold shadow-lg"
+              >
+                {isExporting ? (
+                  <span className="flex items-center gap-2">
+                    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                    Exporting...
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-2">
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                    Export {exportFormat.toUpperCase()}
+                  </span>
+                )}
+              </button>
+            </div>
+          </div>
+          
+          <div className="grid grid-cols-3 gap-4 mt-4 text-sm">
+            <div className="bg-[#11253c]/50 rounded-lg p-3">
+              <div className="font-semibold text-cyan-300 mb-1">Included in Export</div>
+              <ul className="space-y-1 text-xs opacity-70">
+                <li>• Full intelligence brief</li>
+                <li>• Evidence & hypotheses</li>
+                <li>• Generated assets</li>
+                <li>• Audit trail</li>
+              </ul>
+            </div>
+            
+            <div className="bg-[#11253c]/50 rounded-lg p-3">
+              <div className="font-semibold text-cyan-300 mb-1">Export Formats</div>
+              <ul className="space-y-1 text-xs opacity-70">
+                <li>• ZIP: Complete package</li>
+                <li>• PDF: Formatted report</li>
+                <li>• CSV: Data tables</li>
+                <li>• JSON: Structured data</li>
+              </ul>
+            </div>
+            
+            <div className="bg-[#11253c]/50 rounded-lg p-3">
+              <div className="font-semibold text-cyan-300 mb-1">Requirements</div>
+              <ul className="space-y-1 text-xs opacity-70">
+                <li>• Media Team sign-off</li>
+                <li>• Strategy Head sign-off</li>
+                <li>• No active interrupt</li>
+                <li>• Valid export window</li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add export functionality with multiple format options to Issue view
- Enhance Export page UI with production-ready styling
- Polish global color palette with CSS custom properties
- Fix hardcoded role validation in export endpoint

## Changes
- Added export section to Issue view with format selector (ZIP, PDF, CSV, JSON)
- Updated Export page with enhanced UI showing requirements and contents
- Fixed export validation to use "Media Team" instead of "Analyst"
- Added production-ready CSS variables for consistent theming
- Added smooth transitions and accessibility focus states
- Updated demo shortcuts ledger with D3 implementation notes

## Test plan
- [x] Export buttons appear in Issue view
- [x] Format selector shows all options
- [x] Export page has polished UI
- [x] CSS transitions work smoothly
- [ ] Export validates Media Team + Strategy Head signoffs
- [ ] Railway deployment succeeds

## Notes
- Export formats other than ZIP are UI-only for demo
- Color palette uses CSS custom properties for easy theming
- All shortcuts documented in demo_shortcuts_ledger.md

🤖 Generated with [Claude Code](https://claude.ai/code)